### PR TITLE
fix(css): update css to use new class names

### DIFF
--- a/packages/module/patternfly-docs/content/examples/topology-example.css
+++ b/packages/module/patternfly-docs/content/examples/topology-example.css
@@ -1,12 +1,12 @@
+.ws-extensions-t-about-topology,
 .ws-extensions-t-anchors,
 .ws-extensions-t-control-bar,
 .ws-extensions-t-context-menu,
 .ws-extensions-t-custom-edges,
 .ws-extensions-t-custom-nodes,
 .ws-extensions-t-drag-and-drop,
-.ws-extensions-t-getting-started,
 .ws-extensions-t-layouts,
-.ws-extensions-t-panzoom,
+.ws-extensions-t-pan-and-zoom,
 .ws-extensions-t-selection,
 .ws-extensions-t-sidebar,
 .ws-extensions-t-toolbar {
@@ -22,14 +22,14 @@
   }
 }
 
+.pf-theme-dark .ws-extensions-t-about-topology,
 .pf-theme-dark .ws-extensions-t-anchors,
 .pf-theme-dark .ws-extensions-t-control-bar,
 .pf-theme-dark .ws-extensions-t-context-menu,
 .pf-theme-dark .ws-extensions-t-custom-edges,
 .pf-theme-dark .ws-extensions-t-custom-nodes,
-.pf-theme-dark .ws-extensions-t-getting-started,
 .pf-theme-dark .ws-extensions-t-layouts,
-.pf-theme-dark .ws-extensions-t-panzoom,
+.pf-theme-dark .ws-extensions-t-pan-and-zoom,
 .pf-theme-dark .ws-extensions-t-selection,
 .pf-theme-dark .ws-extensions-t-sidebar,
 .pf-theme-dark .ws-extensions-t-toolbar {


### PR DESCRIPTION
## What
Fixes width of viewport for "Pan and Zoom" and "About Topology" demos.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review

<img width="896" alt="Screenshot 2024-06-11 at 5 02 32 PM" src="https://github.com/edonehoo/react-topology/assets/32821331/38d0a341-6113-4aa5-8e52-a057a8dd55fb">
<img width="893" alt="Screenshot 2024-06-11 at 5 02 25 PM" src="https://github.com/edonehoo/react-topology/assets/32821331/61086a5b-ec3b-4064-bf22-7a49ce22f696">

